### PR TITLE
Update plotting.py

### DIFF
--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -1092,7 +1092,7 @@ def show_return_range(returns, df_weekly):
                           index=['2-sigma returns daily',
                                  '2-sigma returns weekly'])
 
-    print(np.round(var_sigma, 3))
+    print(np.round(var_sigma.values, 3))
 
 
 def plot_turnover(returns, transactions, positions,


### PR DESCRIPTION
Numpy `1.10` fails to perform `np.round(pd.Series, decimals)` on python `2.7.11` with error:

```
round() takes at most 2 arguments (3 given)
```

Works fine with `np.round(pd.Series.values, decimals)`.
